### PR TITLE
Fix error when loading in Wayland sessions

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -61,7 +61,14 @@ var WireGuardIndicator = GObject.registerClass(
             this._settings = Convenience.getSettings();
 
             /* Icon indicator */
-            Gtk.IconTheme.get_default().append_search_path(
+            let theme = Gtk.IconTheme.get_default();
+            if (theme == null) {
+                // Workaround due to lazy initialization on wayland
+                // as proposed by @fmuellner in GNOME mutter issue #960
+                theme = new Gtk.IconTheme();
+                theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
+            }
+            theme.append_search_path(
                 Extension.dir.get_child('icons').get_path());
 
             let box = new St.BoxLayout();

--- a/prefs.js
+++ b/prefs.js
@@ -122,7 +122,12 @@ var WireGuarIndicatorPreferencesWidget = GObject.registerClass(
         _init(){
             super._init();
 
-            Gtk.IconTheme.get_default().append_search_path(
+            let theme = Gtk.IconTheme.get_default();
+            if (theme == null) {
+                theme = new Gtk.IconTheme();
+                theme.set_custom_theme(St.Settings.get().gtk_icon_theme);
+            }
+            theme.append_search_path(
                 Extension.dir.get_child('icons').get_path());
 
             let preferencesPage = new PreferencesWidget.Page();


### PR DESCRIPTION
Due to changes in GNOME mutter when using Xwayland, GTK may not be
available for extensions at loading time. This results in
Gtk.IconTheme.get_default() returning null and prevents the extension
from loading properly.
This issue is also documented here:
https://gitlab.gnome.org/GNOME/mutter/-/issues/960

This commit creates a custom theme with the gtk_icon_theme
settings value if the get_default() method returns null, as
suggested in the issue linked above.

This pull request fixes issue #6.