### PR TITLE
[feat]: Early exit if any one service is active

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -173,6 +173,7 @@ var WireGuardIndicator = GObject.registerClass(
             this._servicesSwitches.forEach((serviceSwitch)=>{
                 if(serviceSwitch.state){
                     isActive = true;
+                    return;
                 }
             });
             if(this._isActive == null || this._isActive != isActive){


### PR DESCRIPTION
User will be indicated if any one service is active. Checking all services(repeatative) can be avoided by an early exit.